### PR TITLE
Feature/api doc building restructured

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ for all languages that are activated in the configuration.
 We are pulling the documentation from the openproject core at `https://github.com/opf/openproject/tree/documentation/help` so that Birthe can
 work in peace on her changes for now.
 
-To update the core docs use `OPENPROJECT_CORE=/path/to/openproject ./scripts/pull_repos.rb`
-with the `OPENPROJECT_CORE` path pointing to the checkout of the core with the branch set to to the current release branch (or whatever branch you make changes on)
+To update the core docs use `OPENPROJECT_CORE=/path/to/openproject rake build`
+with the `OPENPROJECT_CORE` being the *absolute* path pointing to the checkout of the core with the branch set to to the current release branch (or whatever branch you make changes on)
 
 This will place all relevant guides under `help/` into the `source/localizable/openproject/*` folders and replace some README.md files into `README.index.html`
 so that middleman will use them as index files.

--- a/data/default_nav.yaml
+++ b/data/default_nav.yaml
@@ -43,7 +43,6 @@ sections:
   - title: API documentation
     path: '/api'
     generate_categories: true
-    has_index_html: false
-    prioritized_order:
-      - /api/basic-objects
-      - /api/group-objects
+    #prioritized_order:
+    #  - /api/general-rest-api-v3
+    #  - /api/bcf-rest-api

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -6,6 +6,42 @@ require 'fileutils'
 require 'parallel'
 require 'psych' # required for .to_yaml
 
+def rename_md_file(path)
+  renamed = path.gsub(/\.md$/, '.html.md')
+
+  if renamed.end_with? 'README.html.md'
+    renamed.gsub! 'README.html.md', 'index.html.md'
+  end
+
+  FileUtils.mv path, renamed
+end
+
+def frontmatter_string(headers)
+  header_string = headers.map do |key, value|
+    if value.is_a?(Hash)
+      "#{key}:\n" + value.map { |k, v| "    #{k}: #{v}" }.join("\n")
+    else
+      "#{key}: #{value}"
+    end
+  end.join("\n")
+
+  <<~FRONTMATTER
+      ---
+      #{header_string}
+      ---
+  FRONTMATTER
+end
+
+# Copies the file from target to source and prepends the frontmatter style headers to it.
+def frontmattered_file_copy(headers, target_path, source_path)
+  input = File.read source_path
+
+  File.open(target_path, 'w') do |f|
+    f.puts frontmatter_string(headers)
+    f.puts input
+  end
+end
+
 desc 'Build and publish to Github Pages'
 task :build do
   middleman_root = File.expand_path('../../', __dir__)
@@ -52,25 +88,26 @@ task :build do
 
   puts 'Renaming index files to match directory index'
   Dir.glob("#{localizable_path}/**/*.md").each do |path|
-    target = path.gsub(/\.md$/, '.html.md')
-
-    if target.end_with? 'README.html.md'
-      target.gsub! 'README.html.md', 'index.html.md'
-    end
-
-    FileUtils.mv path, target
+    rename_md_file(path)
   end
 
   puts 'Building API docs'
   Dir.chdir(File.join(middleman_root, 'api-builder')) do
     core_path = Pathname.new ENV['OPENPROJECT_CORE']
+    api_source_dir = File.join(core_path.to_s, 'docs', 'api')
     apiv3_source_dir = File.join(core_path.to_s, 'docs', 'api', 'apiv3')
     bcf_source_dir = File.join(core_path.to_s, 'docs', 'api', 'bcf')
     target_dir = File.join(middleman_root, 'source', 'api')
+    v3_target_dir = File.join(middleman_root, 'source', 'api', 'general-rest-api-v3')
+    bcf_target_dir = File.join(middleman_root, 'source', 'api', 'bcf-rest-api')
     aglio_path = File.join(middleman_root, 'node_modules', '.bin', 'aglio')
 
     FileUtils.rm_rf target_dir
     FileUtils.mkdir_p target_dir
+    FileUtils.mkdir_p v3_target_dir
+    FileUtils.mkdir_p bcf_target_dir
+
+    FileUtils.copy File.join(api_source_dir, 'README.md'), File.join(target_dir, "index.html.md")
 
     Parallel.each(Dir.glob("#{apiv3_source_dir}/**/*.apib"), progress: 'Processing APIv3 entries') do |api_file|
       filepath = Pathname.new(api_file)
@@ -84,32 +121,38 @@ task :build do
       filename = 'index' if filename == 'introduction'
 
       # Create a filename under API
-      target_path = File.join(target_dir, "#{filename}.html.erb")
+      target_path = File.join(v3_target_dir, "#{filename}.html.erb")
 
       # Execute aglio on that file
       `NOCACHE=1 #{aglio_path} -t openproject-docs-single-page.jade -i #{api_file} -o #{target_path}`
 
-      # Add the frontmatter
-      input = File.read target_path
+      headers = { source_path: relative_file }
 
-      File.open(target_path, 'w') do |f|
-        f.puts <<~FRONTMATTER
-          ---
-          source_path: #{relative_file}
-          ---
-        FRONTMATTER
-        f.puts input
+      # Define the specific title of the introduction page
+      # and place it before the bcf api
+      case filename
+      when 'index'
+        headers['title'] = 'General purpose REST API v3'
+        headers['sidebar_navigation'] = { priority: 1000 }
+      when 'basic-objects'
+        headers['sidebar_navigation'] = { priority: 900 }
+      when 'group-objects'
+        headers['sidebar_navigation'] = { priority: 800 }
+      when 'forms'
+        headers['sidebar_navigation'] = { priority: 700 }
       end
+
+      frontmattered_file_copy(headers, target_path, target_path)
     end
 
     Parallel.each(Dir.glob("#{bcf_source_dir}/**/*.md"), progress: 'Processing BCF entries') do |api_file|
       filepath = Pathname.new(api_file)
-      puts api_file
-      puts target_dir
-      filename = filepath.basename('.md').to_s
+      target_path = File.join(bcf_target_dir, "index.html.md")
+      relative_file = filepath.relative_path_from(core_path)
 
-      # Copy file to API
-      FileUtils.copy api_file, File.join(target_dir, "#{filename}.html.md")
+      headers = { source_path: relative_file, sidebar_navigation: { priority: 500 } }
+
+      frontmattered_file_copy(headers, target_path, api_file)
     end
   end
 

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -6,6 +6,160 @@ require 'fileutils'
 require 'parallel'
 require 'psych' # required for .to_yaml
 
+class APIBuilder
+  def self.build
+    new.build
+  end
+
+  def build
+    Dir.chdir(File.join(middleman_root, 'api-builder')) do
+      cleanup_prior_run
+      create_target_dir
+      copy_introduction
+      build_v3
+      build_bcf
+    end
+  end
+
+  def cleanup_prior_run
+    FileUtils.rm_rf target_dir
+  end
+
+  def create_target_dir
+    FileUtils.mkdir_p target_dir
+  end
+
+  # Copy basic API v3 vs BCF introduction
+  def copy_introduction
+    FileUtils.copy(File.join(api_source_dir, 'README.md'), File.join(target_dir, "index.html.md"))
+  end
+
+  def build_v3
+    copy_endpoints_index
+
+    Parallel.each(Dir.glob("#{apiv3_source_dir}/**/*.apib"), progress: 'Processing APIv3 entries') do |api_file|
+      aglio_v3_file(api_file)
+    end
+  end
+
+  def build_bcf
+    bcf_source_dir = File.join(core_path.to_s, 'docs', 'api', 'bcf')
+    bcf_target_dir = File.join(middleman_root, 'source', 'api', 'bcf-rest-api')
+    FileUtils.mkdir_p bcf_target_dir
+
+    Parallel.each(Dir.glob("#{bcf_source_dir}/**/*.md"), progress: 'Processing BCF entries') do |api_file|
+      filepath = Pathname.new(api_file)
+      target_path = File.join(bcf_target_dir, "index.html.md")
+      relative_file = filepath.relative_path_from(core_path)
+
+      headers = frontmatter_header(:bcf_api, relative_file)
+      frontmattered_file_copy(headers, target_path, api_file)
+    end
+  end
+
+  def copy_endpoints_index
+    # Copy endpoints index file
+    FileUtils.mkdir_p endpoints_target_dir
+    endpoints_index_path = File.join(endpoints_target_dir, "index.html.md")
+    endpoints_source_path = File.join(apiv3_source_dir, 'endpoints', 'README.md')
+    FileUtils.copy(endpoints_source_path, endpoints_index_path)
+    frontmattered_file_copy(frontmatter_header(:endpoints, endpoints_source_path,  { title: 'Endpoints' }), endpoints_index_path, endpoints_index_path)
+  end
+
+  def aglio_v3_file(api_file)
+    filepath = Pathname.new(api_file)
+    relative_file = filepath.relative_path_from(core_path)
+    filename = filepath.basename('.apib').to_s
+    dirname = filepath.each_filename.to_a[-2]
+
+    # Ignore the index file
+    return if filename == 'index'
+
+    target_path = if dirname == 'endpoints'
+                    File.join(target_dir, 'endpoints', "#{filename}.html.erb")
+                  else
+                    FileUtils.mkdir_p File.join(target_dir, filename)
+                    File.join(target_dir, filename, "index.html.erb")
+                  end
+
+    # Execute aglio on that file
+    `NOCACHE=1 #{aglio_path} -t openproject-docs-single-page.jade -i #{api_file} -o #{target_path}`
+
+    headers = frontmatter_header(filename, relative_file, filename == 'introduction' ? { title: 'Introduction' }: {})
+
+    frontmattered_file_copy(headers, target_path, target_path)
+  end
+
+  # Define the specific title of the introduction page
+  # and determine the order the pages are to be listed in.
+  # Place everything before the bcf api page.
+  def frontmatter_header(filename, relative_file, additions = {})
+    { source_path: relative_file, sidebar_navigation: { priority: api_priority(filename) } }.merge(additions)
+  end
+
+  def frontmatter_string(headers)
+    header_string = headers.map do |key, value|
+      if value.is_a?(Hash)
+        "#{key}:\n" + value.map { |k, v| "    #{k}: #{v}" }.join("\n")
+      else
+        "#{key}: #{value}"
+      end
+    end.join("\n")
+
+    <<~FRONTMATTER
+      ---
+      #{header_string}
+      ---
+    FRONTMATTER
+  end
+
+  # Copies the file from target to source and prepends the frontmatter style headers to it.
+  def frontmattered_file_copy(headers, target_path, source_path)
+    input = File.read source_path
+
+    File.open(target_path, 'w') do |f|
+      f.puts frontmatter_string(headers)
+      f.puts input
+    end
+  end
+
+  def api_priority(key)
+    {
+      endpoints: 600,
+      introduction: 900,
+      'basic-objects': 890,
+      'group-objects': 880,
+      forms: 870,
+      filters: 860,
+      bcf_api: 500
+    }[key.to_sym] || 800
+  end
+
+  def core_path
+    Pathname.new ENV['OPENPROJECT_CORE']
+  end
+
+  def api_source_dir
+    File.join(core_path.to_s, 'docs', 'api')
+  end
+
+  def endpoints_target_dir
+    File.join(middleman_root, 'source', 'api', 'endpoints')
+  end
+
+  def apiv3_source_dir
+    File.join(core_path.to_s, 'docs', 'api', 'apiv3')
+  end
+
+  def target_dir
+    File.join(middleman_root, 'source', 'api')
+  end
+
+  def aglio_path
+    File.join(middleman_root, 'node_modules', '.bin', 'aglio')
+  end
+end
+
 def rename_md_file(path)
   renamed = path.gsub(/\.md$/, '.html.md')
 
@@ -16,36 +170,12 @@ def rename_md_file(path)
   FileUtils.mv path, renamed
 end
 
-def frontmatter_string(headers)
-  header_string = headers.map do |key, value|
-    if value.is_a?(Hash)
-      "#{key}:\n" + value.map { |k, v| "    #{k}: #{v}" }.join("\n")
-    else
-      "#{key}: #{value}"
-    end
-  end.join("\n")
-
-  <<~FRONTMATTER
-      ---
-      #{header_string}
-      ---
-  FRONTMATTER
-end
-
-# Copies the file from target to source and prepends the frontmatter style headers to it.
-def frontmattered_file_copy(headers, target_path, source_path)
-  input = File.read source_path
-
-  File.open(target_path, 'w') do |f|
-    f.puts frontmatter_string(headers)
-    f.puts input
-  end
+def middleman_root
+  File.expand_path('../../', __dir__)
 end
 
 desc 'Build and publish to Github Pages'
 task :build do
-  middleman_root = File.expand_path('../../', __dir__)
-
   core_docs = ENV['OPENPROJECT_CORE']
   raise 'Missing OPENPROJECT_CORE env' unless core_docs
 
@@ -92,70 +222,7 @@ task :build do
   end
 
   puts 'Building API docs'
-  Dir.chdir(File.join(middleman_root, 'api-builder')) do
-    core_path = Pathname.new ENV['OPENPROJECT_CORE']
-    api_source_dir = File.join(core_path.to_s, 'docs', 'api')
-    apiv3_source_dir = File.join(core_path.to_s, 'docs', 'api', 'apiv3')
-    bcf_source_dir = File.join(core_path.to_s, 'docs', 'api', 'bcf')
-    target_dir = File.join(middleman_root, 'source', 'api')
-    v3_target_dir = File.join(middleman_root, 'source', 'api', 'general-rest-api-v3')
-    bcf_target_dir = File.join(middleman_root, 'source', 'api', 'bcf-rest-api')
-    aglio_path = File.join(middleman_root, 'node_modules', '.bin', 'aglio')
-
-    FileUtils.rm_rf target_dir
-    FileUtils.mkdir_p target_dir
-    FileUtils.mkdir_p v3_target_dir
-    FileUtils.mkdir_p bcf_target_dir
-
-    FileUtils.copy File.join(api_source_dir, 'README.md'), File.join(target_dir, "index.html.md")
-
-    Parallel.each(Dir.glob("#{apiv3_source_dir}/**/*.apib"), progress: 'Processing APIv3 entries') do |api_file|
-      filepath = Pathname.new(api_file)
-      relative_file = filepath.relative_path_from(core_path)
-      filename = filepath.basename('.apib').to_s
-
-      # Ignore the index file
-      next if filename == 'index'
-
-      # Make introduction the new index
-      filename = 'index' if filename == 'introduction'
-
-      # Create a filename under API
-      target_path = File.join(v3_target_dir, "#{filename}.html.erb")
-
-      # Execute aglio on that file
-      `NOCACHE=1 #{aglio_path} -t openproject-docs-single-page.jade -i #{api_file} -o #{target_path}`
-
-      headers = { source_path: relative_file }
-
-      # Define the specific title of the introduction page
-      # and place it before the bcf api
-      case filename
-      when 'index'
-        headers['title'] = 'General purpose REST API v3'
-        headers['sidebar_navigation'] = { priority: 1000 }
-      when 'basic-objects'
-        headers['sidebar_navigation'] = { priority: 900 }
-      when 'group-objects'
-        headers['sidebar_navigation'] = { priority: 800 }
-      when 'forms'
-        headers['sidebar_navigation'] = { priority: 700 }
-      end
-
-      frontmattered_file_copy(headers, target_path, target_path)
-    end
-
-    Parallel.each(Dir.glob("#{bcf_source_dir}/**/*.md"), progress: 'Processing BCF entries') do |api_file|
-      filepath = Pathname.new(api_file)
-      target_path = File.join(bcf_target_dir, "index.html.md")
-      relative_file = filepath.relative_path_from(core_path)
-
-      headers = { source_path: relative_file, sidebar_navigation: { priority: 500 } }
-
-      frontmattered_file_copy(headers, target_path, api_file)
-    end
-  end
-
+  APIBuilder.build
   puts 'Done.'
 
   if no_git


### PR DESCRIPTION
As the API documentation is growing, this PR nests the part that is working as a compendium about end points into its own submenu. This opens up room for having the general part listed before this, including the newly written example (https://github.com/opf/openproject/pull/8699), and the BCF documentation after it which, while not being as good as having separate menu items for the two apis visually supports the difference between the two.