### PR TITLE
Layout width changes

### DIFF
--- a/source/layouts/_header.html.erb
+++ b/source/layouts/_header.html.erb
@@ -7,13 +7,13 @@
     <a class="header-link logo-container flex-container justify-center align-center" href="<%= root_path %>">
       <%= image_tag "openproject-logo-white.svg", class: 'logo' %>
       <div class="header--separator hidden-for-mobile"></div>
-      <div class="header--help-text hidden-for-mobile">Help</div>
+      <div class="header--help-text hidden-for-mobile">Docs</div>
     </a>
     <% unless current_page.data.disable_searchbar || current_page.url.include?('/search') %>
       <form id="search-form">
         <i class="fa fa-search hidden-for-desktop" aria-hidden="true" data-gl-class-toggle="active" data-target=".header--element-container"></i>
         <i class="fa fa-arrow-left hidden-for-desktop" aria-hidden="true" data-gl-class-toggle="active" data-target=".header--element-container"></i>
-        <input type="text" name="q" class="docsearch-input docsearch" placeholder="Search ..." required/>
+        <input type="text" name="q" class="docsearch-input docsearch" placeholder="Search our docs" required/>
         <input type="submit" style="visibility: hidden; position:absolute;" />
       </form>
     <% end %>

--- a/source/layouts/_landing_header.html.erb
+++ b/source/layouts/_landing_header.html.erb
@@ -4,7 +4,7 @@
       <%= image_tag "openproject-logo-white.svg", class: 'logo hidden-for-mobile' %>
       <%= image_tag "openproject-logo-white-small.svg", class: 'logo hidden-for-desktop' %>
       <div class="header--separator hidden-for-mobile"></div>
-      <div class="header--help-text hidden-for-mobile">Help</div>
+      <div class="header--help-text hidden-for-mobile">Docs</div>
     </a>
     <nav class="landing-header--button-group">
       <%= partial 'layouts/language_dropdown' %>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -2,8 +2,9 @@
   <%#= TODO partial 'layouts/gtm' %>
   <%= partial 'layouts/header' %>
   <div class="wrapper">
+  <div class="container-fluid px-0 d-flex">
     <div class="nav-wrapper">
-      <aside id="global-nav" class="global-nav">
+      <aside id="global-nav" class="global-nav d-block d-lg-flex justify-content-none justify-content-lg-end">
         <%= partial 'layouts/sidebar_navigation' %>
       </aside>
       <button type="button" class="btn nav-toggle hidden-for-mobile" data-gl-class-toggle="active" data-target=".nav-wrapper">
@@ -42,6 +43,7 @@
     <div class="content-overlay"></div>
     <div class="clear"></div>
   </div>
+ </div>
 
   <%#= TODO mermaid.js support ? partial 'layouts/mermaid' %>
 <% end %>

--- a/webpack/stylesheets/header.scss
+++ b/webpack/stylesheets/header.scss
@@ -18,7 +18,6 @@
   }
 
   .logo-container {
-    margin-right: 30px;
 
     .header--help-text {
       font-size: 24px;
@@ -197,6 +196,7 @@
     border-color: $header-color;
     background: transparent;
     color: white;
+    margin-left: 30px;
 
     &:focus {
       background: white !important;

--- a/webpack/stylesheets/index.scss
+++ b/webpack/stylesheets/index.scss
@@ -28,7 +28,7 @@ $fa-font-path: '~@fortawesome/fontawesome-free/webfonts';
 
 .main {
   margin: 0px;
-  padding: $header-height 25px 0;
+  padding: $header-height 48px 0;
   position: relative;
   width: auto;
   max-width: 80%;

--- a/webpack/stylesheets/navigation.scss
+++ b/webpack/stylesheets/navigation.scss
@@ -3,7 +3,7 @@
   display: flex;
   flex-direction: column;
   padding-top: 56px;
-  max-width: 220px;
+  //max-width: 220px;
   width: 0px;
   transition: all .3s;
   background: $global-nav-bg;
@@ -11,10 +11,10 @@
   z-index: 2;
 
   &.active {
-    width: 15%;
+    width: 20%;
 
     @media(max-width:1100px) {
-      width: 20%;
+      width: 30%;
     }
 
     .nav-toggle {

--- a/webpack/stylesheets/navigation.scss
+++ b/webpack/stylesheets/navigation.scss
@@ -3,7 +3,6 @@
   display: flex;
   flex-direction: column;
   padding-top: 56px;
-  //max-width: 220px;
   width: 0px;
   transition: all .3s;
   background: $global-nav-bg;

--- a/webpack/stylesheets/toc.scss
+++ b/webpack/stylesheets/toc.scss
@@ -84,6 +84,7 @@
     top: 0;
     right: 8px;
     margin-top: $header-height;
+    background-color: $global-nav-bg;
     height: 100%;
 
     .toc-collapse {
@@ -109,6 +110,7 @@
 
   .doc-nav {
     width: $doc-nav-width;
+    background-color: $global-nav-bg;
   }
 }
 
@@ -119,12 +121,13 @@
   $doc-nav-width: 21%;
 
   .main.class.has-toc {
-    width: 64vw;
-    max-width: 64vw;
+    width: 58vw;
+    max-width: 58vw;
     margin: 0;
   }
 
   .doc-nav {
     width: $doc-nav-width;
+    background-color: $global-nav-bg;
   }
 }


### PR DESCRIPTION
This pull request includes the following changes:

- The sidebars have been restyled with more consistent spacing and background colors.
- The sidebars now stick to the center and not the edges of the screens.
- The header bar search box on desktop view has been restyled.
- The text in the header bar was changed from "Help" to "Docs" to be consistent with the URL.
- Left and right padding has been added to the content for consistency.

A screenshot of the changes as below:

![image](https://user-images.githubusercontent.com/25004151/94006991-05609880-fda1-11ea-9a19-689f6049531f.png)
